### PR TITLE
Add new topic  "Further Information "

### DIFF
--- a/docs/docs/firmware/state-monitor-esp32.md
+++ b/docs/docs/firmware/state-monitor-esp32.md
@@ -211,19 +211,20 @@ The RJ45 pinout for each port is;
 ## Further Information
 
 ### Downloads
-Download the [latest binary](https://github.com/SuperHouse/OXRS-SHA-StateMonitor-ESP32-FW/releases) of the firmware from GitHub
+Download the [latest binary](https://github.com/SuperHouse/OXRS-SHA-StateMonitor-ESP32-FW/releases) of the firmware from GitHub.
 
-Download the [source code](https://github.com/SuperHouse/OXRS-SHA-StateMonitor-ESP32-FW) of the firmware from GitHub
+Download the [source code](https://github.com/SuperHouse/OXRS-SHA-StateMonitor-ESP32-FW) of the firmware from GitHub.
 
 ### Flash Binary
 How to [flash the binary](/guides/getting-started.html#Firmware).
 
 ### Home Automation Integration
-examples how to integrate StateMonitor into Home Automation systems
+Below are some examples of how you could integrate with various home automation systems.
 
-[Home Assistant integration examples](/guides/advanced/home_assistant.html)
+[Home Assistant](https://www.home-assistant.io/) integration [examples](/guides/advanced/home_assistant.html).
 
-[Node Red integration examples](/guides/advanced/node_red.html)
+[Node-RED](https://nodered.org/) integration [examples](/guides/advanced/node_red.html).
+
 
 
 

--- a/docs/docs/firmware/state-monitor-esp32.md
+++ b/docs/docs/firmware/state-monitor-esp32.md
@@ -185,9 +185,6 @@ A triple button click on input 4;
 ```
 
 
-## Downloads
-Download the latest version of the firmware on [Github](https://github.com/SuperHouse/OXRS-SHA-StateMonitor-ESP32-FW).
-
 
 ## Supported Hardware
 This firmware is compatible with the [Light Switch Controller](https://github.com/SuperHouse/LSC) (LSC) and is designed to run on the [RACK32](/docs/hardware/controllers/rack32.html) as part of the [OXRS](https://oxrs.io) eco-system.
@@ -210,6 +207,26 @@ The RJ45 pinout for each port is;
 |6  |INPUT 4    |
 |7  |GND        |
 |8  |GND        |
+
+## Further Information
+
+### Downloads
+Download the [latest binary](https://github.com/SuperHouse/OXRS-SHA-StateMonitor-ESP32-FW/releases) of the firmware from GitHub
+
+Download the [source code](https://github.com/SuperHouse/OXRS-SHA-StateMonitor-ESP32-FW) of the firmware from GitHub
+
+### Flash Binary
+How to [flash the binary](/guides/getting-started.html#Firmware).
+
+### Home Automation Integration
+examples how to integrate StateMonitor into Home Automation systems
+
+[Home Assistant integration examples](/guides/advanced/home_assistant.html)
+
+[Node Red integration examples](/guides/advanced/node_red.html)
+
+
+
 
 
 #### Credits

--- a/docs/guides/advanced/README.md
+++ b/docs/guides/advanced/README.md
@@ -5,8 +5,9 @@ tags: [""]
  Includes:
 
 ## Software
- - [Home Assistant](/guides/advanced/home_assistant.html) Sample automations to work with StateMonitor
- - [Node Red](/guides/advanced/node_red.html) Sample flows to work with StateMonitor
+ - [Home Assistant](/guides/advanced/home_assistant.html) Sample automations to work with  [State Monitor](/docs/firmware/state-monitor-esp32.html)
+ - [Node-RED](/guides/advanced/node_red.html) sample flows to work with [State Monitor](/docs/firmware/state-monitor-esp32.html)
+ 
  - mqtt
 
 ## Building Firmware

--- a/docs/guides/advanced/README.md
+++ b/docs/guides/advanced/README.md
@@ -6,7 +6,7 @@ tags: [""]
 
 ## Software
  - [Home Assistant](/guides/advanced/home_assistant.html) Sample automations to work with StateMonitor
- - node red
+ - [Node Red](/guides/advanced/node_red.html) Sample flows to work with StateMonitor
  - mqtt
 
 ## Building Firmware

--- a/docs/guides/advanced/home_assistant.md
+++ b/docs/guides/advanced/home_assistant.md
@@ -1,4 +1,4 @@
-# OXRS StateMonitor Home Assistant integration
+# OXRS Home Assistant integrations
 
 
 ## Introduction

--- a/docs/guides/advanced/home_assistant.md
+++ b/docs/guides/advanced/home_assistant.md
@@ -2,21 +2,22 @@
 
 
 ## Introduction
-This guide shows `automation` samples to be used in Home Assistant. They make use of the event structure that is sent by the StateMonitor via MQTT
+This guide shows `automation` samples to be used in Home Assistant. They make use of the event structure that is sent by the StateMonitor via MQTT.
 
 For details on `configuration` and `events` see the [StateMonitor](/docs/firmware/state-monitor-esp32.html) documentation.
 
 The following samples are using the config topic `conf/58391f` and the state topic `stat/58391f`. Those are the defaults as allocated by the FW using the MAC address of the device. Index numbers need to be replaced according to your set up.
 
-All samples are based on Home Assistant [MQTT triggers](https://www.home-assistant.io/docs/automation/trigger/#mqtt-trigger) were a template filters the payload sent by the StateMonitor via `stat/..` for the desired `index` and `event`
+All samples are based on Home Assistant [MQTT triggers](https://www.home-assistant.io/docs/automation/trigger/#mqtt-trigger) were a template filters the payload sent by the StateMonitor via `stat/..` for the desired `index` and `event`.
+
+## Example set 1 (inputs), related to State Monitor, State IO and Smoke Detector
 
 
-
-### Example 1: Use a `switch` to turn light on and off 
+### Example 1.1: Use a `switch` to turn light on and off 
 ---
 #### Typical use case : standard wall switch. 
 
-to configure input `index: 5`  as `switch` publish : 
+To configure input `index: 5`  as `switch` publish : 
 ```
  -t conf/58391f  -m '{"inputs": [{ "index": 5 , "type": "switch"}]}'
  ```
@@ -53,11 +54,11 @@ automation:
 
 
 
-### Example 2: Use two `toggle` buttons to toggle a light state from several locations
+### Example 1.2: Use two `toggle` buttons to toggle a light state from several locations
 ---
 #### Typical use cases: hallway lighting or bedroom lighting.
 
-to configure inputs `index: 1` and `index: 2`  as `toggle` publish : 
+To configure inputs `index: 1` and `index: 2`  as `toggle` publish : 
 ```
  -t conf/58391f  -m '{"inputs": [{"index": 2, "type": "toggle"},{"index": 1, "type": "toggle" }]}'
 ```
@@ -94,11 +95,11 @@ Can be as many buttons as you like, just add more conditions:
 
 
 
-### Example 3: Use two `buttons` to control brightness and state of a light bulb
+### Example 1.3: Use two `buttons` to control brightness and state of a light bulb
 ---
-#### Typical use case: control of lights with variable brightness with up and down buttons
+#### Typical use case: control of lights with variable brightness with up and down buttons.
 
-to configure inputs `index: 1` and `index: 2`  as `buttons` publish : 
+To configure inputs `index: 1` and `index: 2`  as `buttons` publish : 
 ```
  -t conf/58391f  -m '{"inputs": [{"index": 2, "type": "button"},{"index": 1, "type": "button" }]}'
 ```
@@ -177,9 +178,9 @@ automation:
         brightness_step_pct: 5     
 ```
 
-### Example 4: Use a rotary encoder with integrated button to control brightness and state of a light bulb
+### Example 1.4: Use a rotary encoder with integrated button to control brightness and state of a light bulb
 ---
-#### Typical use case: single knob control of lights with variable brightness via a rotary encoder
+#### Typical use case: single knob control of lights with variable brightness via a rotary encoder.
 The outputs `A` and `B` of the `rotary encoder` are connected to `index: 1` and `index: 2` . The integrated `push button` of the `rotary encoder` is connected to `index: 3` .
 
 To configure inputs `index: 1` and `index: 2`  as `rotary` and `index:3` as `toggle` publish : 
@@ -260,4 +261,17 @@ automation:
     - service: light.toggle
       target:
         entity_id: light.light_bulb
+```
+
+
+## Example set 2 (outputs), related to State Controller, State IO and Smoke Detector
+
+### Example 2.1: Turn light bulb on and off 
+---
+#### Typical use case : standard light bulb controlled by wall switch. 
+
+```
+
+To Do
+
 ```

--- a/docs/guides/advanced/node_red.md
+++ b/docs/guides/advanced/node_red.md
@@ -1,0 +1,112 @@
+# OXRS StateMonitor Node Red integration
+
+
+## Introduction
+This guide shows `automation` samples to be used Node Red. They make use of the event structure that is sent by the StateMonitor via MQTT
+
+For details on `configuration` and `events` see the [StateMonitor](/docs/firmware/state-monitor-esp32.html) documentation.
+
+The following samples are using the config topic `conf/58391f` and the state topic `stat/58391f`. Those are the defaults as allocated by the FW using the MAC address of the device. Index numbers need to be replaced according to your set up.
+
+
+
+### Example 1: Use a `switch` to turn light on and off 
+---
+#### Typical use case : standard wall switch. 
+
+to configure input `index: 5`  as `switch` publish : 
+```
+ -t conf/58391f  -m '{"inputs": [{ "index": 5 , "type": "switch"}]}'
+ ```
+ 
+use configured switch to turn a light on / off.
+```
+
+To Do
+
+```
+
+
+
+### Example 2: Use two `toggle` buttons to toggle a light state from several locations
+---
+#### Typical use cases: hallway lighting or bedroom lighting.
+
+to configure inputs `index: 1` and `index: 2`  as `toggle` publish : 
+```
+ -t conf/58391f  -m '{"inputs": [{"index": 2, "type": "toggle"},{"index": 1, "type": "toggle" }]}'
+```
+ 
+Use configured buttons to toggle connected light by any of the buttons.
+```
+
+To Do
+
+```
+::: tip
+Can be as many buttons as you like, just add more conditions:
+```
+
+To Do
+
+```
+:::
+
+
+
+### Example 3: Use two `buttons` to control brightness and state of a light bulb
+---
+#### Typical use case: control of lights with variable brightness with up and down buttons
+
+to configure inputs `index: 1` and `index: 2`  as `buttons` publish : 
+```
+ -t conf/58391f  -m '{"inputs": [{"index": 2, "type": "button"},{"index": 1, "type": "button" }]}'
+```
+This is a more complex automation. It uses the `single` and `hold` events from each of the 2 involved buttons.
+The `single` event is used to control the state of the light bulb and the `hold` event for brightness control.
+
+
+|index|event   |function
+|:----|:-------|:-------|
+|1    |single  |turn off |
+|1    |hold    |decrease brightness  |
+|2    |single  |turn on |
+|2    |hold    |increase brightness  |
+
+```
+
+To Do
+
+```
+
+### Example 4: Use a rotary encoder with integrated button to control brightness and state of a light bulb
+---
+#### Typical use case: single knob control of lights with variable brightness via a rotary encoder
+The outputs `A` and `B` of the `rotary encoder` are connected to `index: 1` and `index: 2` . The integrated `push button` of the `rotary encoder` is connected to `index: 3` .
+
+To configure inputs `index: 1` and `index: 2`  as `rotary` and `index:3` as `toggle` publish : 
+```
+ -t conf/58391f -m '{"inputs": [
+    {"index": 1, "type": "rotary"},
+    {"index": 2, "type": "rotary"},
+    {"index": 3, "type": "toggle"}]}'
+
+```
+This is another more complex automation. It uses the `up` and `down` events from the rotary encoder for brightness control.
+The `toggle` event of the integrated push button is used to control the state of the light bulb.
+
+Turning the rotary encoder has no effect if the light is turned off.
+
+
+|index|event   |function
+|:----|:-------|:-------|
+|2    |up      |increase brightness  |
+|2    |down    |decrease brightness  |
+|3    |toggle  |turn on / off |
+
+
+```
+
+To Do
+
+```

--- a/docs/guides/advanced/node_red.md
+++ b/docs/guides/advanced/node_red.md
@@ -1,25 +1,25 @@
-# OXRS StateMonitor Node Red integration
+# OXRS Node-RED integrations
 
 
 ## Introduction
-This guide shows `automation` samples to be used Node Red. They make use of the event structure that is sent by the StateMonitor via MQTT
+This guide shows `automation` samples to be used in Node-RED. They make use of the event structure that is sent by the StateMonitor via MQTT.
 
 For details on `configuration` and `events` see the [StateMonitor](/docs/firmware/state-monitor-esp32.html) documentation.
 
 The following samples are using the config topic `conf/58391f` and the state topic `stat/58391f`. Those are the defaults as allocated by the FW using the MAC address of the device. Index numbers need to be replaced according to your set up.
 
+## Example set 1 (inputs), related to State Monitor, State IO and Smoke Detector
 
-
-### Example 1: Use a `switch` to turn light on and off 
+### Example 1.1: Use a `switch` to turn light on and off
 ---
 #### Typical use case : standard wall switch. 
 
-to configure input `index: 5`  as `switch` publish : 
+To configure input `index: 5`  as `switch` publish : 
 ```
  -t conf/58391f  -m '{"inputs": [{ "index": 5 , "type": "switch"}]}'
  ```
  
-use configured switch to turn a light on / off.
+Use configured switch to turn a light on / off.
 ```
 
 To Do
@@ -28,11 +28,11 @@ To Do
 
 
 
-### Example 2: Use two `toggle` buttons to toggle a light state from several locations
+### Example 1.2: Use two `toggle` buttons to toggle a light state from several locations
 ---
 #### Typical use cases: hallway lighting or bedroom lighting.
 
-to configure inputs `index: 1` and `index: 2`  as `toggle` publish : 
+To configure inputs `index: 1` and `index: 2`  as `toggle` publish : 
 ```
  -t conf/58391f  -m '{"inputs": [{"index": 2, "type": "toggle"},{"index": 1, "type": "toggle" }]}'
 ```
@@ -54,11 +54,11 @@ To Do
 
 
 
-### Example 3: Use two `buttons` to control brightness and state of a light bulb
+### Example 1.3: Use two `buttons` to control brightness and state of a light bulb
 ---
-#### Typical use case: control of lights with variable brightness with up and down buttons
+#### Typical use case: control of lights with variable brightness with up and down buttons.
 
-to configure inputs `index: 1` and `index: 2`  as `buttons` publish : 
+To configure inputs `index: 1` and `index: 2`  as `buttons` publish : 
 ```
  -t conf/58391f  -m '{"inputs": [{"index": 2, "type": "button"},{"index": 1, "type": "button" }]}'
 ```
@@ -79,9 +79,9 @@ To Do
 
 ```
 
-### Example 4: Use a rotary encoder with integrated button to control brightness and state of a light bulb
+### Example 1.4: Use a rotary encoder with integrated button to control brightness and state of a light bulb
 ---
-#### Typical use case: single knob control of lights with variable brightness via a rotary encoder
+#### Typical use case: single knob control of lights with variable brightness via a rotary encoder.
 The outputs `A` and `B` of the `rotary encoder` are connected to `index: 1` and `index: 2` . The integrated `push button` of the `rotary encoder` is connected to `index: 3` .
 
 To configure inputs `index: 1` and `index: 2`  as `rotary` and `index:3` as `toggle` publish : 
@@ -103,6 +103,20 @@ Turning the rotary encoder has no effect if the light is turned off.
 |2    |up      |increase brightness  |
 |2    |down    |decrease brightness  |
 |3    |toggle  |turn on / off |
+
+
+```
+
+To Do
+
+```
+
+
+## Example set 2 (outputs), related to State Controller, State IO and Smoke Detector
+
+### Example 2.1: Turn light bulb on and off 
+---
+#### Typical use case : standard light bulb controlled by wall switch. 
 
 
 ```


### PR DESCRIPTION
@sumnerboy12 here is a proposal for an additional topic that could be added to each FW-doc with links to corresponding information, download, etc.  Some content behind the links is not complete, but should give an idea.

@MakerDockio the pages under guides/getting-started-guides look broken (different than Docs). may be you can have alook?