### PR TITLE
Update 'Compatible Hardware' links in rack32.md

### DIFF
--- a/docs/docs/hardware/controllers/rack32.md
+++ b/docs/docs/hardware/controllers/rack32.md
@@ -67,4 +67,8 @@ TODO - Jon to supply some FAQ's
 :::
 
 ## Compatible Hardware
-- Universal Input/Output (UIO) 16Port [Link](/docs/hardware/input-output-devices/smoke-detector-sd-16port.md)
+Input/Output devices
+* [I2CRJ45 / Light Switch Controller](/docs/hardware/input-devices/I2CRJ45.md) by SuperHouse
+
+Shields
+* [Rack32 KNX Shield] (/docs/hardware/shields/rack32-knx-shield.md) by Frank McAlinden


### PR DESCRIPTION
Correct broken link. Original document appears to have been removed. Repointing link to Jonathon Oxer's I2CRJ45 page.

Plus added a compatible shield.